### PR TITLE
chore: update repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
     ca-certificates \
     curl \
     git \
+    python3-venv \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/lv_conf_example/lv_conf_drm_4_threads.h
+++ b/lv_conf_example/lv_conf_drm_4_threads.h
@@ -698,7 +698,7 @@
 /*File system interfaces for common APIs */
 
 /*Setting a default driver letter allows skipping the driver prefix in filepaths*/
-#define LV_FS_DEFAULT_DRIVE_LETTER '\0'
+#define LV_FS_DEFAULT_DRIVER_LETTER '\0'
 
 /*API for fopen, fread, etc*/
 #define LV_USE_FS_STDIO 1

--- a/lv_conf_example/lv_conf_fb_1_thread.h
+++ b/lv_conf_example/lv_conf_fb_1_thread.h
@@ -698,7 +698,7 @@
 /*File system interfaces for common APIs */
 
 /*Setting a default driver letter allows skipping the driver prefix in filepaths*/
-#define LV_FS_DEFAULT_DRIVE_LETTER '\0'
+#define LV_FS_DEFAULT_DRIVER_LETTER '\0'
 
 /*API for fopen, fread, etc*/
 #define LV_USE_FS_STDIO 1

--- a/lv_conf_example/lv_conf_fb_4_threads.h
+++ b/lv_conf_example/lv_conf_fb_4_threads.h
@@ -698,7 +698,7 @@
 /*File system interfaces for common APIs */
 
 /*Setting a default driver letter allows skipping the driver prefix in filepaths*/
-#define LV_FS_DEFAULT_DRIVE_LETTER '\0'
+#define LV_FS_DEFAULT_DRIVER_LETTER '\0'
 
 /*API for fopen, fread, etc*/
 #define LV_USE_FS_STDIO 1

--- a/lv_conf_example/lv_conf_wayland_4_threads.h
+++ b/lv_conf_example/lv_conf_wayland_4_threads.h
@@ -698,7 +698,7 @@
 /*File system interfaces for common APIs */
 
 /*Setting a default driver letter allows skipping the driver prefix in filepaths*/
-#define LV_FS_DEFAULT_DRIVE_LETTER '\0'
+#define LV_FS_DEFAULT_DRIVER_LETTER '\0'
 
 /*API for fopen, fread, etc*/
 #define LV_USE_FS_STDIO 1


### PR DESCRIPTION
This  PR
- Updates the lv_conf examples to use the new `LV_FS_DEFAULT_DRIVER_LETTER`
- Updates lv_port_linux to its latest version and also adds `python3-venv` which is now a build dependency for it

In the future we should migrate to `lv_conf.defaults`
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch lv_conf example headers to LV_FS_DEFAULT_DRIVER_LETTER and update lv_port_linux to the latest version for upstream compatibility. Add python3-venv to the Docker image to satisfy the port’s build dependency and prevent build failures.

<!-- End of auto-generated description by cubic. -->

